### PR TITLE
Update common.yml / `empty description on issue`

### DIFF
--- a/reviewpad-models/common.yml
+++ b/reviewpad-models/common.yml
@@ -99,11 +99,11 @@ workflows:
           - $titleLint()
 
   - name: empty description on issue
-    description: Check if the issue has a description.
+    description: Check if the issue has a description when adding to Reviewpad project
     on:
       - issue
     run:
-      - if: $description() == ""
+      - if: '$description() == "" && $isLinkedToProject("Reviewpad")'
         then: $close("Automatically closing this issue. Please add a description.")
   
   - name: empty description on pull request


### PR DESCRIPTION
Update `empty description on issue` to only work on addition to project

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 09 Aug 23 15:31 UTC
This pull request updates the `empty description on issue` workflow in the `common.yml` file. The update ensures that the check for an empty description only works when adding an issue to the Reviewpad project.
<!-- reviewpad:summarize:end -->

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->
