### PR TITLE
fix: update common.yml

### DIFF
--- a/reviewpad-models/common.yml
+++ b/reviewpad-models/common.yml
@@ -99,11 +99,11 @@ workflows:
           - $titleLint()
 
   - name: empty description on issue
-    description: Check if the issue has a description and was created more 1 day ago
+    description: Check if the issue has a description and was created more 2 minutes ago
     on:
       - issue
     run:
-      - if: $description() == "" && $createdAt() > 1 day ago
+      - if: $description() == "" && $createdAt() < 2 minutes ago
         then: $close("Automatically closing this issue. Please add a description.")
   
   - name: empty description on pull request


### PR DESCRIPTION
Update `empty description on issue` with `$createdAt() < 2 minutes ago`

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 10 Aug 23 09:53 UTC
This pull request updates the `empty description on issue` check in `common.yml` file. The check now verifies if the issue has a description and was created less than 2 minutes ago, instead of more than 1 day ago as before. This change allows for a more immediate response in automatically closing the issue if it lacks a description.
<!-- reviewpad:summarize:end -->

## Code review and merge strategy

**Ship**: this pull request can be automatically merged and does not require code review
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
<!-- **Ask**: this pull request requires a code review before merge -->
